### PR TITLE
feat: Настройка аутентификации и авторизации в БД

### DIFF
--- a/src/main/java/ru/skypro/homework/HomeworkApplication.java
+++ b/src/main/java/ru/skypro/homework/HomeworkApplication.java
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class HomeworkApplication {
-  public static void main(String[] args) {
-    SpringApplication.run(HomeworkApplication.class, args);
-  }
+    public static void main(String[] args) {
+        SpringApplication.run(HomeworkApplication.class, args);
+    }
 }

--- a/src/main/java/ru/skypro/homework/config/WebSecurityConfig.java
+++ b/src/main/java/ru/skypro/homework/config/WebSecurityConfig.java
@@ -16,12 +16,15 @@ import static org.springframework.security.config.Customizer.withDefaults;
 public class WebSecurityConfig {
 
     private static final String[] AUTH_WHITELIST = {
+            "/",
             "/swagger-resources/**",
             "/swagger-ui.html",
             "/v3/api-docs",
             "/webjars/**",
             "/login",
-            "/register"
+            "/register",
+            "/swagger-ui/**",
+            "/swagger-ui/index.html"
     };
 
     @Bean

--- a/src/main/java/ru/skypro/homework/config/WebSecurityConfig.java
+++ b/src/main/java/ru/skypro/homework/config/WebSecurityConfig.java
@@ -3,13 +3,12 @@ package ru.skypro.homework.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.provisioning.JdbcUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
-import ru.skypro.homework.dto.Role;
+
+import javax.sql.DataSource;
 
 import static org.springframework.security.config.Customizer.withDefaults;
 
@@ -26,31 +25,40 @@ public class WebSecurityConfig {
     };
 
     @Bean
-    public InMemoryUserDetailsManager userDetailsService(PasswordEncoder passwordEncoder) {
-        UserDetails user =
-                User.builder()
-                        .username("user@gmail.com")
-                        .password("password")
-                        .passwordEncoder(passwordEncoder::encode)
-                        .roles(Role.USER.name())
-                        .build();
-        return new InMemoryUserDetailsManager(user);
+    public JdbcUserDetailsManager userDetailsService(DataSource dataSource, PasswordEncoder passwordEncoder) {
+        JdbcUserDetailsManager manager = new JdbcUserDetailsManager(dataSource);
+
+        manager.setUsersByUsernameQuery(
+                "SELECT username, password, enabled FROM users WHERE username = ?"
+        );
+
+        manager.setAuthoritiesByUsernameQuery(
+                "SELECT username, authority FROM authorities WHERE username = ?"
+        );
+
+        return manager;
     }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http.csrf()
-                .disable()
-                .authorizeHttpRequests(
-                        authorization ->
-                                authorization
-                                        .mvcMatchers(AUTH_WHITELIST)
-                                        .permitAll()
-                                        .mvcMatchers("/ads/**", "/users/**")
-                                        .authenticated())
-                .cors()
-                .and()
-                .httpBasic(withDefaults());
+        http
+                .csrf().disable()
+                .authorizeHttpRequests(authorization ->
+                        authorization
+                                .antMatchers(AUTH_WHITELIST).permitAll()
+                                .antMatchers("/admin/**").hasRole("ADMIN")
+                                .antMatchers("/user/**").hasAnyRole("USER", "ADMIN")
+                                .antMatchers("/ads/**", "/users/**").authenticated()
+                                .anyRequest().denyAll()
+                )
+                .httpBasic(withDefaults())
+                .headers(headers ->
+                        headers
+                                .xssProtection()
+                                .and()
+                                .contentSecurityPolicy("script-src 'self'")
+                );
+
         return http.build();
     }
 
@@ -58,5 +66,4 @@ public class WebSecurityConfig {
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
-
 }

--- a/src/main/java/ru/skypro/homework/controller/AdsController.java
+++ b/src/main/java/ru/skypro/homework/controller/AdsController.java
@@ -32,6 +32,7 @@ public class AdsController {
     @GetMapping
     @Operation(
             summary = "Получение всех объявлений",
+            description = "Возвращает список всех объявлений. Доступно всем пользователям.",
             responses = {
                     @ApiResponse(
                             responseCode = "200",
@@ -44,6 +45,7 @@ public class AdsController {
             }
     )
     public Ads getAllAds() {
+        log.info("Запрос на получение всех объявлений");
         List<Ad> ads = adService.getAllAds();
         Ads response = new Ads();
         response.setCount(ads.size());
@@ -54,6 +56,7 @@ public class AdsController {
     @PostMapping(consumes = "multipart/form-data")
     @Operation(
             summary = "Добавление объявления",
+            description = "Создает новое объявление. Доступно только авторизованным пользователям.",
             responses = {
                     @ApiResponse(
                             responseCode = "201",
@@ -70,6 +73,7 @@ public class AdsController {
     public Integer addAd(
             @RequestPart("properties") CreateOrUpdateAd properties,
             @RequestPart("image") MultipartFile image) {
+        log.info("Запрос на добавление объявления");
         Ad ad = adService.addAd(properties, image);
         return ad.getPk();
     }
@@ -77,6 +81,7 @@ public class AdsController {
     @GetMapping("/{id}")
     @Operation(
             summary = "Получение информации об объявлении",
+            description = "Возвращает подробную информацию об объявлении по ID. Доступно всем пользователям.",
             responses = {
                     @ApiResponse(
                             responseCode = "200",
@@ -86,17 +91,18 @@ public class AdsController {
                                     schema = @Schema(implementation = ExtendedAd.class)
                             )
                     ),
-                    @ApiResponse(responseCode = "401", description = "Unauthorized"),
                     @ApiResponse(responseCode = "404", description = "Not found")
             }
     )
     public ExtendedAd getAd(@PathVariable Integer id) {
+        log.info("Запрос на получение объявления с ID: {}", id);
         return adService.getAd(id);
     }
 
     @DeleteMapping("/{id}")
     @Operation(
             summary = "Удаление объявления",
+            description = "Удаляет объявление по ID. Доступно только автору объявления или администратору.",
             responses = {
                     @ApiResponse(responseCode = "204", description = "No Content"),
                     @ApiResponse(responseCode = "401", description = "Unauthorized"),
@@ -106,12 +112,14 @@ public class AdsController {
     )
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeAd(@PathVariable Integer id) {
+        log.info("Запрос на удаление объявления с ID: {}", id);
         adService.removeAd(id);
     }
 
     @PatchMapping("/{id}")
     @Operation(
             summary = "Обновление информации об объявлении",
+            description = "Обновляет информацию об объявлении. Доступно только автору объявления или администратору.",
             responses = {
                     @ApiResponse(
                             responseCode = "200",
@@ -129,25 +137,28 @@ public class AdsController {
     public Ad updateAd(
             @PathVariable Integer id,
             @RequestBody CreateOrUpdateAd updatedAd) {
+        log.info("Запрос на обновление объявления с ID: {}", id);
         return adService.updateAd(id, updatedAd);
     }
 
     @GetMapping("/me")
     @Operation(
             summary = "Получение объявлений авторизованного пользователя",
+            description = "Возвращает список объявлений текущего авторизованного пользователя.",
             responses = {
                     @ApiResponse(
                             responseCode = "200",
                             description = "OK",
                             content = @Content(
                                     mediaType = "application/json",
-                                    schema = @Schema(implementation = Ad.class)
+                                    schema = @Schema(implementation = Ads.class)
                             )
                     ),
                     @ApiResponse(responseCode = "401", description = "Unauthorized")
             }
     )
     public Ads getAdsMe() {
+        log.info("Запрос на получение объявлений текущего пользователя");
         List<Ad> ads = adService.getAdsMe();
         Ads response = new Ads();
         response.setCount(ads.size());
@@ -158,6 +169,7 @@ public class AdsController {
     @PatchMapping(value = "/{id}/image", consumes = "multipart/form-data")
     @Operation(
             summary = "Обновление картинки объявления",
+            description = "Обновляет изображение объявления. Доступно только автору объявления или администратору.",
             responses = {
                     @ApiResponse(
                             responseCode = "200",
@@ -175,6 +187,7 @@ public class AdsController {
     public ResponseEntity<byte[]> updateImage(
             @PathVariable Integer id,
             @RequestPart("image") MultipartFile image) {
+        log.info("Запрос на обновление изображения объявления с ID: {}", id);
         byte[] imageBytes = adService.updateImage(id, image);
         return ResponseEntity.ok(imageBytes);
     }

--- a/src/main/java/ru/skypro/homework/controller/CommentsController.java
+++ b/src/main/java/ru/skypro/homework/controller/CommentsController.java
@@ -29,6 +29,7 @@ public class CommentsController {
     @GetMapping
     @Operation(
             summary = "Получение комментариев объявления",
+            description = "Возвращает список комментариев для указанного объявления. Доступно всем пользователям.",
             responses = {
                     @ApiResponse(
                             responseCode = "200",
@@ -38,11 +39,11 @@ public class CommentsController {
                                     schema = @Schema(implementation = Comments.class)
                             )
                     ),
-                    @ApiResponse(responseCode = "401", description = "Unauthorized"),
                     @ApiResponse(responseCode = "404", description = "Not found")
             }
     )
     public Comments getComments(@PathVariable Integer id) {
+        log.info("Запрос на получение комментариев для объявления с ID: {}", id);
         List<Comment> comments = commentService.getComments(id);
         Comments response = new Comments();
         response.setCount(comments.size());
@@ -53,10 +54,11 @@ public class CommentsController {
     @PostMapping
     @Operation(
             summary = "Добавление комментария к объявлению",
+            description = "Создает новый комментарий для указанного объявления. Доступно только авторизованным пользователям.",
             responses = {
                     @ApiResponse(
-                            responseCode = "200",
-                            description = "OK",
+                            responseCode = "201",
+                            description = "Created",
                             content = @Content(
                                     mediaType = "application/json",
                                     schema = @Schema(implementation = Comment.class)
@@ -70,6 +72,7 @@ public class CommentsController {
     public Integer addComment(
             @PathVariable Integer id,
             @RequestBody CreateOrUpdateComment comment) {
+        log.info("Запрос на добавление комментария к объявлению с ID: {}", id);
         Comment createdComment = commentService.addComment(id, comment);
         return createdComment.getPk();
     }
@@ -77,6 +80,7 @@ public class CommentsController {
     @DeleteMapping("/{commentId}")
     @Operation(
             summary = "Удаление комментария",
+            description = "Удаляет комментарий по ID. Доступно только автору комментария или администратору.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "OK"),
                     @ApiResponse(responseCode = "401", description = "Unauthorized"),
@@ -88,12 +92,14 @@ public class CommentsController {
     public void deleteComment(
             @PathVariable Integer id,
             @PathVariable Integer commentId) {
+        log.info("Запрос на удаление комментария с ID: {} для объявления с ID: {}", commentId, id);
         commentService.deleteComment(id, commentId);
     }
 
     @PatchMapping("/{commentId}")
     @Operation(
             summary = "Обновление комментария",
+            description = "Обновляет информацию о комментарии. Доступно только автору комментария или администратору.",
             responses = {
                     @ApiResponse(
                             responseCode = "200",
@@ -112,6 +118,7 @@ public class CommentsController {
             @PathVariable Integer id,
             @PathVariable Integer commentId,
             @RequestBody CreateOrUpdateComment updatedComment) {
+        log.info("Запрос на обновление комментария с ID: {} для объявления с ID: {}", commentId, id);
         return commentService.updateComment(id, commentId, updatedComment);
     }
 }

--- a/src/main/java/ru/skypro/homework/controller/GlobalExceptionHandler.java
+++ b/src/main/java/ru/skypro/homework/controller/GlobalExceptionHandler.java
@@ -36,10 +36,10 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(ImageUploadException.class)
-    public ResponseEntity<Map<String, String>> handleImageUploadException(ImageUploadException ex) {
-        Map<String, String> error = new HashMap<>();
-        error.put("message", ex.getMessage());
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
+    public ResponseEntity<String> handleImageUploadException(ImageUploadException ex) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ex.getMessage());
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/ru/skypro/homework/controller/UserController.java
+++ b/src/main/java/ru/skypro/homework/controller/UserController.java
@@ -37,8 +37,8 @@ public class UserController {
                     @ApiResponse(responseCode = "403", description = "Доступ запрещен")
             }
     )
-    public Long setPassword(@RequestBody NewPassword newPassword) {
-        return userService.updatePassword(newPassword);
+    public void setPassword(@RequestBody NewPassword newPassword) {
+        userService.updatePassword(newPassword);
     }
 
     @GetMapping("/me")
@@ -78,7 +78,7 @@ public class UserController {
                     @ApiResponse(responseCode = "401", description = "Неавторизованный доступ")
             }
     )
-    public UpdateUser updateUser(@RequestBody UpdateUser updateUser) {
+    public ru.skypro.homework.model.User updateUser(@RequestBody UpdateUser updateUser) {
         return userService.updateUser(updateUser);
     }
 

--- a/src/main/java/ru/skypro/homework/exception/ImageUploadException.java
+++ b/src/main/java/ru/skypro/homework/exception/ImageUploadException.java
@@ -1,6 +1,10 @@
 package ru.skypro.homework.exception;
 
 public class ImageUploadException extends RuntimeException {
+    public ImageUploadException(String message) {
+        super(message);
+    }
+
     public ImageUploadException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/src/main/java/ru/skypro/homework/filter/BasicAuthCorsFilter.java
+++ b/src/main/java/ru/skypro/homework/filter/BasicAuthCorsFilter.java
@@ -18,6 +18,9 @@ public class BasicAuthCorsFilter extends OncePerRequestFilter {
                                     HttpServletResponse httpServletResponse,
                                     FilterChain filterChain)
             throws ServletException, IOException {
+        httpServletResponse.addHeader("Access-Control-Allow-Origin", "*");
+        httpServletResponse.addHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
+        httpServletResponse.addHeader("Access-Control-Allow-Headers", "Authorization, Content-Type");
         httpServletResponse.addHeader("Access-Control-Allow-Credentials", "true");
         filterChain.doFilter(httpServletRequest, httpServletResponse);
     }

--- a/src/main/java/ru/skypro/homework/mapper/UserMapper.java
+++ b/src/main/java/ru/skypro/homework/mapper/UserMapper.java
@@ -51,4 +51,6 @@ public interface UserMapper {
     @Mapping(source = "lastName", target = "lastName")
     @Mapping(source = "phone", target = "phone")
     void updateUserFromDTO(UpdateUser updateUser, @MappingTarget ru.skypro.homework.model.User user);
+
+    ru.skypro.homework.model.User toDTO(ru.skypro.homework.model.User user);
 }

--- a/src/main/java/ru/skypro/homework/service/UserService.java
+++ b/src/main/java/ru/skypro/homework/service/UserService.java
@@ -1,13 +1,24 @@
 package ru.skypro.homework.service;
 
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.multipart.MultipartFile;
 import ru.skypro.homework.dto.NewPassword;
 import ru.skypro.homework.dto.UpdateUser;
 import ru.skypro.homework.model.User;
 
 public interface UserService {
-    Long updatePassword(NewPassword newPassword);
+
+
+    void updatePassword(NewPassword newPassword);
+
+    @PreAuthorize("#username == authentication.principal.username")
     User getCurrentUser();
-    UpdateUser updateUser(UpdateUser updateUser);
+
+    @PreAuthorize("#username == authentication.principal.username")
+    User updateUser(UpdateUser updateUser);
+
+    @PreAuthorize("#username == authentication.principal.username")
     void updateUserImage(MultipartFile image);
+
+
 }

--- a/src/main/java/ru/skypro/homework/service/impl/AdServiceImpl.java
+++ b/src/main/java/ru/skypro/homework/service/impl/AdServiceImpl.java
@@ -35,7 +35,9 @@ public class AdServiceImpl implements AdService {
     @Override
     public List<Ad> getAllAds() {
         logger.info("Fetching all ads");
-        return adMapper.adsToAdDTOs(adRepository.findAll());
+        List<ru.skypro.homework.model.Ad> ads = adRepository.findAll();
+        logger.info("Found {} ads", ads.size());
+        return adMapper.adsToAdDTOs(ads);
     }
 
     @Override
@@ -49,7 +51,7 @@ public class AdServiceImpl implements AdService {
         try {
             ad.setImage(Arrays.toString(image.getBytes()));
         } catch (IOException e) {
-            logger.error("Failed to upload image", e);
+            logger.error("Failed to upload image for ad by user: {}", currentUser.getUsername(), e);
             throw new ImageUploadException("Ошибка при загрузке изображения", e);
         }
 
@@ -67,6 +69,7 @@ public class AdServiceImpl implements AdService {
                     logger.error("Ad not found with id: {}", id);
                     return new AdNotFoundException("Объявление не найдено");
                 });
+        logger.info("Ad found with id: {}", id);
         return adMapper.adToExtendedAdDTO(ad);
     }
 
@@ -122,7 +125,10 @@ public class AdServiceImpl implements AdService {
         User currentUser = userService.getCurrentUser();
         logger.info("Fetching ads for user: {}", currentUser.getUsername());
 
-        return adMapper.adsToAdDTOs(adRepository.findByAuthor(currentUser));
+        List<ru.skypro.homework.model.Ad> ads = adRepository.findByAuthor(currentUser);
+        logger.info("Found {} ads for user: {}", ads.size(), currentUser.getUsername());
+
+        return adMapper.adsToAdDTOs(ads);
     }
 
     @Override
@@ -148,7 +154,7 @@ public class AdServiceImpl implements AdService {
             logger.info("Image updated successfully for ad with id: {}", id);
             return imageBytes;
         } catch (IOException e) {
-            logger.error("Failed to upload image", e);
+            logger.error("Failed to upload image for ad with id: {}", id, e);
             throw new ImageUploadException("Ошибка при загрузке изображения", e);
         }
     }

--- a/src/main/java/ru/skypro/homework/service/impl/AuthServiceImpl.java
+++ b/src/main/java/ru/skypro/homework/service/impl/AuthServiceImpl.java
@@ -35,7 +35,6 @@ public class AuthServiceImpl implements AuthService {
             return false;
         }
 
-        // Создаем пользователя в Spring Security
         manager.createUser(
                 org.springframework.security.core.userdetails.User.withUsername(register.getUsername())
                         .passwordEncoder(this.encoder::encode)

--- a/src/main/java/ru/skypro/homework/service/impl/CommentServiceImpl.java
+++ b/src/main/java/ru/skypro/homework/service/impl/CommentServiceImpl.java
@@ -36,7 +36,9 @@ public class CommentServiceImpl implements CommentService {
     @Override
     public List<Comment> getComments(Integer adId) {
         logger.info("Fetching comments for ad with id: {}", adId);
-        return commentMapper.commentsToCommentDTOs(commentRepository.findByAdId(adId));
+        List<ru.skypro.homework.model.Comment> comments = commentRepository.findByAdId(adId);
+        logger.info("Found {} comments for ad with id: {}", comments.size(), adId);
+        return commentMapper.commentsToCommentDTOs(comments);
     }
 
     @Override

--- a/src/main/resources/db/changelog/V1__Create_authorities_table.xml
+++ b/src/main/resources/db/changelog/V1__Create_authorities_table.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="1" author="Lins">
+        <createTable tableName="authorities">
+            <column name="username" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="authority" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint
+                baseTableName="authorities"
+                baseColumnNames="username"
+                referencedTableName="users"
+                referencedColumnNames="username"
+                constraintName="fk_authorities_users"
+                onDelete="CASCADE"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/V1__Create_comments_table.xml
+++ b/src/main/resources/db/changelog/V1__Create_comments_table.xml
@@ -3,33 +3,53 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
 
-    <changeSet id="create-comments-table" author="Lins">
+    <!-- Создание таблицы comments -->
+    <changeSet id="1" author="Lins">
         <createTable tableName="comments">
+            <!-- Уникальный идентификатор -->
             <column name="id" type="INTEGER" autoIncrement="true">
                 <constraints primaryKey="true" nullable="false"/>
             </column>
+
+            <!-- Текст комментария -->
             <column name="text" type="TEXT">
                 <constraints nullable="false"/>
             </column>
+
+            <!-- Дата создания комментария -->
             <column name="created_at" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
+
+            <!-- Автор комментария (внешний ключ на users) -->
             <column name="author_id" type="BIGINT">
                 <constraints nullable="false"/>
             </column>
+
+            <!-- Объявление, к которому относится комментарий (внешний ключ на ads) -->
             <column name="ad_id" type="INTEGER">
                 <constraints nullable="false"/>
             </column>
         </createTable>
 
-        <addForeignKeyConstraint baseTableName="comments" baseColumnNames="author_id"
-                                 constraintName="fk_comments_author"
-                                 referencedTableName="users" referencedColumnNames="id"/>
+        <!-- Внешний ключ на таблицу users -->
+        <addForeignKeyConstraint
+                baseTableName="comments"
+                baseColumnNames="author_id"
+                referencedTableName="users"
+                referencedColumnNames="id"
+                constraintName="fk_comments_author"
+                onDelete="CASCADE"/> <!-- Каскадное удаление -->
 
-        <addForeignKeyConstraint baseTableName="comments" baseColumnNames="ad_id"
-                                 constraintName="fk_comments_ad"
-                                 referencedTableName="ads" referencedColumnNames="id"/>
+        <!-- Внешний ключ на таблицу ads -->
+        <addForeignKeyConstraint
+                baseTableName="comments"
+                baseColumnNames="ad_id"
+                referencedTableName="ads"
+                referencedColumnNames="id"
+                constraintName="fk_comments_ad"
+                onDelete="CASCADE"/> <!-- Каскадное удаление -->
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/V1__Create_users_table.xml
+++ b/src/main/resources/db/changelog/V1__Create_users_table.xml
@@ -7,41 +7,75 @@
 
     <changeSet id="1" author="lins">
         <createTable tableName="users">
+            <!-- Уникальный идентификатор -->
             <column name="id" type="BIGINT" autoIncrement="true">
                 <constraints primaryKey="true" nullable="false"/>
             </column>
 
+            <!-- Логин пользователя -->
             <column name="username" type="VARCHAR(50)">
                 <constraints nullable="false" unique="true"/>
             </column>
 
+            <!-- Пароль пользователя -->
             <column name="password" type="VARCHAR(100)">
                 <constraints nullable="false"/>
             </column>
 
+            <!-- Флаг активности -->
+            <column name="enabled" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+
+            <!-- Имя пользователя -->
             <column name="first_name" type="VARCHAR(50)">
                 <constraints nullable="false"/>
             </column>
 
+            <!-- Фамилия пользователя -->
             <column name="last_name" type="VARCHAR(50)">
                 <constraints nullable="false"/>
             </column>
 
-            <column name="phone" type="VARCHAR(20)">
-                <constraints nullable="false"/>
-            </column>
-
+            <!-- Email пользователя -->
             <column name="email" type="VARCHAR(100)">
                 <constraints nullable="false" unique="true"/>
             </column>
 
-            <column name="role" type="VARCHAR(20)">
+            <!-- Телефон пользователя -->
+            <column name="phone" type="VARCHAR(20)">
                 <constraints nullable="false"/>
             </column>
 
+            <!-- Ссылка на изображение -->
             <column name="image_url" type="VARCHAR(255)">
                 <constraints nullable="true"/>
             </column>
+
+            <!-- Роль пользователя -->
+            <column name="role" type="VARCHAR(20)">
+                <constraints nullable="false"/>
+            </column>
         </createTable>
+    </changeSet>
+
+    <!-- Таблица authorities -->
+    <changeSet id="2" author="Lins">
+        <createTable tableName="authorities">
+            <column name="username" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="authority" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <!-- Внешний ключ для authorities -->
+        <addForeignKeyConstraint
+                baseTableName="authorities"
+                baseColumnNames="username"
+                referencedTableName="users"
+                referencedColumnNames="username"
+                constraintName="fk_authorities_users"/>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/V1__Create_users_table.xml
+++ b/src/main/resources/db/changelog/V1__Create_users_table.xml
@@ -58,24 +58,4 @@
             </column>
         </createTable>
     </changeSet>
-
-    <!-- Таблица authorities -->
-    <changeSet id="2" author="Lins">
-        <createTable tableName="authorities">
-            <column name="username" type="VARCHAR(50)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="authority" type="VARCHAR(50)">
-                <constraints nullable="false"/>
-            </column>
-        </createTable>
-
-        <!-- Внешний ключ для authorities -->
-        <addForeignKeyConstraint
-                baseTableName="authorities"
-                baseColumnNames="username"
-                referencedTableName="users"
-                referencedColumnNames="username"
-                constraintName="fk_authorities_users"/>
-    </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -8,4 +8,5 @@
     <include file="/V1__Create_users_table.xml" relativeToChangelogFile="true"/>
     <include file="/V1__Create_ads_table.xml" relativeToChangelogFile="true"/>
     <include file="/V1__Create_comments_table.xml" relativeToChangelogFile="true"/>
+    <include file="V1__Create_authorities_table.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/test/java/ru/skypro/homework/controller/AuthControllerTest.java
+++ b/src/test/java/ru/skypro/homework/controller/AuthControllerTest.java
@@ -1,0 +1,94 @@
+package ru.skypro.homework.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import ru.skypro.homework.dto.Login;
+import ru.skypro.homework.dto.Register;
+import ru.skypro.homework.service.AuthService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@DisplayName("Тестирование контроллера AuthController")
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthService authService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("Авторизация пользователя - успешно")
+    void login_ShouldReturnOk() throws Exception {
+        Login login = new Login();
+        login.setUsername("user");
+        login.setPassword("password");
+
+        when(authService.login(login.getUsername(), login.getPassword())).thenReturn(true);
+
+        mockMvc.perform(post("/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(login)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Авторизация пользователя - неверные учетные данные")
+    void login_ShouldReturnUnauthorized() throws Exception {
+        Login login = new Login();
+        login.setUsername("user");
+        login.setPassword("wrongpassword");
+
+        when(authService.login(login.getUsername(), login.getPassword())).thenReturn(false);
+
+        mockMvc.perform(post("/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(login)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("Регистрация пользователя - успешно")
+    void register_ShouldReturnCreated() throws Exception {
+        Register register = new Register();
+        register.setUsername("newuser");
+        register.setPassword("password");
+
+        when(authService.register(any(Register.class))).thenReturn(true);
+
+        mockMvc.perform(post("/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(register)))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("Регистрация пользователя - некорректные данные")
+    void register_ShouldReturnBadRequest() throws Exception {
+        Register register = new Register();
+        register.setUsername("invaliduser");
+        register.setPassword("short");
+
+        when(authService.register(any(Register.class))).thenReturn(false);
+
+        mockMvc.perform(post("/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(register)))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
- Заменен InMemoryUserDetailsManager на JdbcUserDetailsManager для хранения пользователей в БД.
- Настроен SecurityFilterChain для обеспечения требований модели безопасности:
  - Добавлены правила авторизации для различных эндпоинтов.
  - Реализована базовая аутентификация (HTTP Basic).
- Добавлены дополнительные проверки ролей в сервисах для операций, требующих повышенной безопасности (например, редактирование чужого комментария или объявления).
- Реализованы сервисы для работы с БД через репозитории:
  - Добавлены методы для работы с пользователями, комментариями и объявлениями.
- Использованы мапперы для преобразования DTO в сущности и обратно:
  - Реализованы мапперы для User, Comment, Ad и соответствующих DTO.
- Обновлены контроллеры для работы с DTO и вызова сервисов.