### PR TITLE
refacor: Исправление миграций и настройка каскадного удаления

### DIFF
--- a/src/main/resources/db/changelog/V1__Create_ads_table.xml
+++ b/src/main/resources/db/changelog/V1__Create_ads_table.xml
@@ -5,27 +5,35 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
 
-    <!-- Создание таблицы ads -->
-    <changeSet id="create-ads-table" author="Lins">
+    <changeSet id="1" author="Lins">
         <createTable tableName="ads">
             <column name="id" type="INTEGER" autoIncrement="true">
                 <constraints primaryKey="true" nullable="false"/>
             </column>
+
             <column name="title" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
+
             <column name="price" type="INTEGER">
                 <constraints nullable="false"/>
             </column>
+
             <column name="description" type="TEXT"/>
+
             <column name="image" type="VARCHAR(255)"/>
+
             <column name="author_id" type="BIGINT">
                 <constraints nullable="false"/>
             </column>
         </createTable>
 
-        <addForeignKeyConstraint baseTableName="ads" baseColumnNames="author_id"
-                                 constraintName="fk_ads_author"
-                                 referencedTableName="users" referencedColumnNames="id"/>
+        <addForeignKeyConstraint
+                baseTableName="ads"
+                baseColumnNames="author_id"
+                referencedTableName="users"
+                referencedColumnNames="id"
+                constraintName="fk_ads_author"
+                onDelete="CASCADE"/>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/V1__Create_authorities_table.xml
+++ b/src/main/resources/db/changelog/V1__Create_authorities_table.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="1" author="Lins">
+        <createTable tableName="authorities">
+            <column name="username" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="authority" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint
+                baseTableName="authorities"
+                baseColumnNames="username"
+                referencedTableName="users"
+                referencedColumnNames="username"
+                constraintName="fk_authorities_users"
+                onDelete="CASCADE"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/V1__Create_comments_table.xml
+++ b/src/main/resources/db/changelog/V1__Create_comments_table.xml
@@ -3,33 +3,45 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
 
-    <changeSet id="create-comments-table" author="Lins">
+    <changeSet id="1" author="Lins">
         <createTable tableName="comments">
             <column name="id" type="INTEGER" autoIncrement="true">
                 <constraints primaryKey="true" nullable="false"/>
             </column>
+
             <column name="text" type="TEXT">
                 <constraints nullable="false"/>
             </column>
+
             <column name="created_at" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
+
             <column name="author_id" type="BIGINT">
                 <constraints nullable="false"/>
             </column>
+
             <column name="ad_id" type="INTEGER">
                 <constraints nullable="false"/>
             </column>
         </createTable>
 
-        <addForeignKeyConstraint baseTableName="comments" baseColumnNames="author_id"
-                                 constraintName="fk_comments_author"
-                                 referencedTableName="users" referencedColumnNames="id"/>
+        <addForeignKeyConstraint
+                baseTableName="comments"
+                baseColumnNames="author_id"
+                referencedTableName="users"
+                referencedColumnNames="id"
+                constraintName="fk_comments_author"
+                onDelete="CASCADE"/>
 
-        <addForeignKeyConstraint baseTableName="comments" baseColumnNames="ad_id"
-                                 constraintName="fk_comments_ad"
-                                 referencedTableName="ads" referencedColumnNames="id"/>
+        <addForeignKeyConstraint
+                baseTableName="comments"
+                baseColumnNames="ad_id"
+                referencedTableName="ads"
+                referencedColumnNames="id"
+                constraintName="fk_comments_ad"
+                onDelete="CASCADE"/>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/V1__Create_users_table.xml
+++ b/src/main/resources/db/changelog/V1__Create_users_table.xml
@@ -5,7 +5,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
 
-    <changeSet id="1" author="lins">
+    <changeSet id="1" author="Lins">
         <createTable tableName="users">
             <column name="id" type="BIGINT" autoIncrement="true">
                 <constraints primaryKey="true" nullable="false"/>
@@ -27,20 +27,20 @@
                 <constraints nullable="false"/>
             </column>
 
-            <column name="phone" type="VARCHAR(20)">
-                <constraints nullable="false"/>
-            </column>
-
             <column name="email" type="VARCHAR(100)">
-                <constraints nullable="false" unique="true"/>
+                <constraints nullable="true" unique="true"/>
             </column>
 
-            <column name="role" type="VARCHAR(20)">
+            <column name="phone" type="VARCHAR(20)">
                 <constraints nullable="false"/>
             </column>
 
             <column name="image_url" type="VARCHAR(255)">
                 <constraints nullable="true"/>
+            </column>
+
+            <column name="role" type="VARCHAR(20)">
+                <constraints nullable="false"/>
             </column>
         </createTable>
     </changeSet>

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -8,4 +8,5 @@
     <include file="/V1__Create_users_table.xml" relativeToChangelogFile="true"/>
     <include file="/V1__Create_ads_table.xml" relativeToChangelogFile="true"/>
     <include file="/V1__Create_comments_table.xml" relativeToChangelogFile="true"/>
+    <include file="/V1__Create_authorities_table.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>


### PR DESCRIPTION
      - Пересозданы миграции для таблиц users, authorities, ads и comments.
      - Добавлены внешние ключи с каскадным удалением:
        - При удалении пользователя удаляются связанные записи в таблицах authorities и ads.
        - При удалении объявления удаляются связанные комментарии. - Убедились, что связи между таблицами работают корректно.